### PR TITLE
攻撃時に敵を撃破、モーションを取得に変更

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1627,7 +1627,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e56e2c6625ad38c4ba0ee79202b3fa35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &537132890
+--- !u!114 &537132879
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1636,10 +1636,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 537132877}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d848f1b2f7abb6b4385341c8f7c19d06, type: 3}
+  m_Script: {fileID: 11500000, guid: 08351928728112841817b33bebccf467, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  motionList: []
+  getMotionList: {fileID: 1261961717}
 --- !u!1001 &537352873
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3580,7 +3580,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -4789,6 +4789,39 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4c8fccd2467cc0b40acbf4f83881452c, type: 3}
+--- !u!1 &1261961716 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6258666651007387591, guid: 4c8fccd2467cc0b40acbf4f83881452c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1261961715}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1261961717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1261961716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d848f1b2f7abb6b4385341c8f7c19d06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  motionList: []
+  anim: {fileID: 0}
+--- !u!135 &1261961718
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1261961716}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.15
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &1264932288
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6832,8 +6865,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 196dcbb12a54a4a48b634eb28519b2d0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 537132877}
-  motions: {fileID: 0}
+  player: {fileID: 1261961716}
 --- !u!1 &1692703939
 GameObject:
   m_ObjectHideFlags: 0
@@ -7420,6 +7452,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   motionList: []
+  anim: {fileID: 0}
 --- !u!1 &1958205293
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Actions.cs
+++ b/Assets/Script/Actions.cs
@@ -9,7 +9,7 @@ public class Actions : MonoBehaviour
     float countTime = 0;
 
     public GameObject player;
-    public GetMotionList motions;
+    GetMotionList motions;
 
     void Start()
     {

--- a/Assets/Script/GetMotionList.cs
+++ b/Assets/Script/GetMotionList.cs
@@ -5,61 +5,27 @@ using UnityEngine;
 public class GetMotionList : MonoBehaviour
 {
     public List<string> motionList = new List<string>();
-    Animator anim;
+    public Animator anim;
+    Collider handCollider;
 
-    void OnCollisionEnter(Collision other)
-    {
-        if (other.gameObject.tag == "Enemy")
-        {
+    void OnTriggerEnter(Collider other) {
+        if (other.gameObject.tag == "Enemy") {
             Animator animator = other.gameObject.GetComponent<Animator>();
             RuntimeAnimatorController ac = animator.runtimeAnimatorController;
             int count = 0;
-            while(count < ac.animationClips.Length)
-            {
+            while (count < ac.animationClips.Length) {
                 motionList.Add(ac.animationClips[count].name);
                 Debug.Log(ac.animationClips[count].name);
                 count++;
             }
-                    
-            
             Destroy(other.gameObject);
         }
     }
-    void Start()
-    {
-        anim = GetComponent<Animator>();
+
+    void Start() {
+        handCollider = GameObject.Find("Character1_LeftHand").GetComponent<SphereCollider>();
     }
 
-    void Update()
-    {
-        //        if (Input.GetKeyDown(KeyCode.A) && !anim.GetCurrentAnimatorStateInfo(0).IsName("Punch") && !anim.IsInTransition(0))
-        if (!Input.GetKeyDown(KeyCode.A) &&
-            !Input.GetKey(KeyCode.UpArrow) && 
-            !Input.GetKey(KeyCode.DownArrow) && 
-            !Input.GetKey(KeyCode.RightArrow) && 
-            !Input.GetKey(KeyCode.LeftArrow) &&
-            (!anim.GetBool("Dance01") ||
-             !anim.GetBool("Dance02")
-             )
-            &&
-            !Input.GetKey(KeyCode.Space)
-            )
-        {
-            foreach(string s in motionList)
-            {
-                string str = s.Substring(10);
-                Debug.Log(str);
-                anim.SetBool(str, true);
-            }
-        }
-        else
-        {
-            foreach (string s in motionList)
-            {
-                string str = s.Substring(10);
-                anim.SetBool(str, false);
-            }
-        }
+    void Update() {
     }
-
 }

--- a/Assets/Script/GetMotionPlay.cs
+++ b/Assets/Script/GetMotionPlay.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GetMotionPlay : MonoBehaviour
+{
+    public GetMotionList getMotionList;
+
+    void Start() {
+        getMotionList.anim = GetComponent<Animator>();
+    }
+
+    void Update() {
+        if (!Input.GetKeyDown(KeyCode.A) &&
+           !Input.GetKey(KeyCode.UpArrow) &&
+           !Input.GetKey(KeyCode.DownArrow) &&
+           !Input.GetKey(KeyCode.RightArrow) &&
+           !Input.GetKey(KeyCode.LeftArrow) &&
+           (!getMotionList.anim.GetBool("Dance01") ||
+            !getMotionList.anim.GetBool("Dance02")
+            )
+           &&
+           !Input.GetKey(KeyCode.Space)
+           ) {
+            foreach (string s in getMotionList.motionList) {
+                string str = s.Substring(10);
+                Debug.Log(str);
+                getMotionList.anim.SetBool(str, true);
+            }
+        } else {
+            foreach (string s in getMotionList.motionList) {
+                string str = s.Substring(10);
+                getMotionList.anim.SetBool(str, false);
+            }
+        }
+    }
+}

--- a/Assets/Script/GetMotionPlay.cs.meta
+++ b/Assets/Script/GetMotionPlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08351928728112841817b33bebccf467
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Player/Attack.cs
+++ b/Assets/Script/Player/Attack.cs
@@ -7,20 +7,26 @@ public class Attack : MonoBehaviour
     Animator animator;
     CharacterController cc;
     Vector3 velocity;
+    Collider handCollider;
     [SerializeField]
     float walkSpeed;
 
-    void Start()
-    {
+    void Start() {
         animator = GetComponent<Animator>();
         cc = GetComponent<CharacterController>();
         velocity = Vector3.zero;
+        handCollider = GameObject.Find("Character1_LeftHand").GetComponent<SphereCollider>();
     }
 
-    void Update()
-    {
+    void Update() {
         if (Input.GetKeyDown(KeyCode.A) && !animator.GetCurrentAnimatorStateInfo(0).IsName("Punch") && !animator.IsInTransition(0)) {
             animator.SetTrigger("Punch");
+            handCollider.enabled = true;
+            Invoke("ColliderReset", 0.3f);
         }
+    }
+
+    void ColliderReset() {
+        handCollider.enabled = false;
     }
 }


### PR DESCRIPTION
敵にぶつかるだけで撃破できていたのを、攻撃したときのみに変更しました。
スクリプト：Attack、GetMotionList追記変更済。GetMotionPlay新規作成。
GetMotionListはPlayerの左手にアタッチ済。AttackとGetMotionPlayはPlayerにアタッチ済。